### PR TITLE
Fix API URL fallback in ranking page

### DIFF
--- a/app/ranking/page.tsx
+++ b/app/ranking/page.tsx
@@ -14,8 +14,9 @@ export default function RankingPage() {
 
   useEffect(() => {
     const fetchRanking = async () => {
+      const apiUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3000';
       try {
-        const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/players/ranking`);
+        const res = await fetch(`${apiUrl}/players/ranking`);
         const data = await res.json();
         setPlayers(data);
       } catch (err) {


### PR DESCRIPTION
## Summary
- ensure ranking page works without NEXT_PUBLIC_API_URL by providing localhost fallback

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68447119f1288331a89b95a6094c7d81