### PR TITLE
Add matches summary page

### DIFF
--- a/app/matches/page.tsx
+++ b/app/matches/page.tsx
@@ -7,11 +7,14 @@ interface Match {
   date: string;
   winner: 'A' | 'B';
   goalDifference: number;
+  teamAPlayers: string[];
+  teamBPlayers: string[];
 }
 
 export default function MatchesPage() {
   const apiUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3000';
   const [matches, setMatches] = useState<Match[]>([]);
+  const [expandedId, setExpandedId] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -66,29 +69,55 @@ export default function MatchesPage() {
         <p style={{ textAlign: 'center', color: 'red' }}>{error}</p>
       ) : (
         <ul style={{ listStyle: 'none', padding: 0 }}>
-          {matches.map((m, i) => (
-            <li
-              key={m.id}
-              style={{
-                display: 'flex',
-                justifyContent: 'space-between',
-                padding: '4px 0',
-                borderBottom: '1px solid #e5e7eb',
-                fontSize: 14,
-              }}
-            >
-              <span style={{ width: 24 }}>{i + 1}.</span>
-              <span style={{ flex: 1 }}>
-                {new Date(m.date).toLocaleDateString()}
-              </span>
-              <span style={{ flex: 1, textAlign: 'center' }}>
-                Ganador: Equipo {m.winner}
-              </span>
-              <span style={{ width: 70, textAlign: 'right' }}>
-                Dif: {m.goalDifference}
-              </span>
-            </li>
-          ))}
+          {matches.map((m, i) => {
+            const expanded = expandedId === m.id;
+            return (
+              <li key={m.id} style={{ borderBottom: '1px solid #e5e7eb', fontSize: 14 }}>
+                <button
+                  onClick={() => setExpandedId(expanded ? null : m.id)}
+                  style={{
+                    all: 'unset',
+                    display: 'flex',
+                    justifyContent: 'space-between',
+                    width: '100%',
+                    padding: '4px 0',
+                    cursor: 'pointer',
+                  }}
+                >
+                  <span style={{ width: 24 }}>{i + 1}.</span>
+                  <span style={{ flex: 1 }}>
+                    {new Date(m.date).toLocaleDateString()}
+                  </span>
+                  <span style={{ flex: 1, textAlign: 'center' }}>
+                    Ganador: Equipo {m.winner}
+                  </span>
+                  <span style={{ width: 70, textAlign: 'right' }}>
+                    Dif: {m.goalDifference}
+                  </span>
+                </button>
+                {expanded && (
+                  <div style={{ display: 'flex', gap: 16, padding: '8px 0' }}>
+                    <div style={{ flex: 1 }}>
+                      <p style={{ fontWeight: 600, marginBottom: 4 }}>Equipo A</p>
+                      <ul style={{ listStyle: 'none', padding: 0 }}>
+                        {m.teamAPlayers.map(p => (
+                          <li key={p}>{p}</li>
+                        ))}
+                      </ul>
+                    </div>
+                    <div style={{ flex: 1 }}>
+                      <p style={{ fontWeight: 600, marginBottom: 4 }}>Equipo B</p>
+                      <ul style={{ listStyle: 'none', padding: 0 }}>
+                        {m.teamBPlayers.map(p => (
+                          <li key={p}>{p}</li>
+                        ))}
+                      </ul>
+                    </div>
+                  </div>
+                )}
+              </li>
+            );
+          })}
         </ul>
       )}
     </main>

--- a/app/matches/page.tsx
+++ b/app/matches/page.tsx
@@ -1,0 +1,96 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+interface Match {
+  id: string;
+  date: string;
+  winner: 'A' | 'B';
+  goalDifference: number;
+}
+
+export default function MatchesPage() {
+  const apiUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3000';
+  const [matches, setMatches] = useState<Match[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchMatches = async () => {
+      try {
+        const res = await fetch(`${apiUrl}/matches/summary`);
+        const data: Match[] = await res.json();
+        data.sort(
+          (a, b) =>
+            new Date(b.date).getTime() - new Date(a.date).getTime()
+        );
+        setMatches(data);
+      } catch (err) {
+        setError('No se pudieron obtener los partidos.');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchMatches();
+  }, []);
+
+  return (
+    <main
+      style={{
+        maxWidth: 480,
+        margin: '48px auto',
+        padding: 24,
+        background: 'white',
+        borderRadius: 12,
+        boxShadow: '0 2px 16px rgba(0,0,0,0.08)',
+        display: 'flex',
+        flexDirection: 'column',
+        minHeight: 400,
+      }}
+    >
+      <h1
+        style={{
+          fontSize: '2rem',
+          fontWeight: 800,
+          marginBottom: 24,
+          textAlign: 'center',
+          color: '#0f172a',
+        }}
+      >
+        Partidos Jugados
+      </h1>
+      {loading ? (
+        <p style={{ textAlign: 'center' }}>Cargando...</p>
+      ) : error ? (
+        <p style={{ textAlign: 'center', color: 'red' }}>{error}</p>
+      ) : (
+        <ul style={{ listStyle: 'none', padding: 0 }}>
+          {matches.map((m, i) => (
+            <li
+              key={m.id}
+              style={{
+                display: 'flex',
+                justifyContent: 'space-between',
+                padding: '4px 0',
+                borderBottom: '1px solid #e5e7eb',
+                fontSize: 14,
+              }}
+            >
+              <span style={{ width: 24 }}>{i + 1}.</span>
+              <span style={{ flex: 1 }}>
+                {new Date(m.date).toLocaleDateString()}
+              </span>
+              <span style={{ flex: 1, textAlign: 'center' }}>
+                Ganador: Equipo {m.winner}
+              </span>
+              <span style={{ width: 70, textAlign: 'right' }}>
+                Dif: {m.goalDifference}
+              </span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </main>
+  );
+}

--- a/app/matches/page.tsx
+++ b/app/matches/page.tsx
@@ -1,18 +1,18 @@
-'use client';
+"use client";
 
-import { useEffect, useState } from 'react';
+import { useEffect, useState } from "react";
 
 interface Match {
   id: string;
   date: string;
-  winner: 'A' | 'B';
+  winner: "A" | "B";
   goalDifference: number;
   teamAPlayers: string[];
   teamBPlayers: string[];
 }
 
 export default function MatchesPage() {
-  const apiUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3000';
+  const apiUrl = process.env.NEXT_PUBLIC_API_URL || "http://localhost:3000";
   const [matches, setMatches] = useState<Match[]>([]);
   const [expandedId, setExpandedId] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
@@ -24,12 +24,11 @@ export default function MatchesPage() {
         const res = await fetch(`${apiUrl}/matches/summary`);
         const data: Match[] = await res.json();
         data.sort(
-          (a, b) =>
-            new Date(b.date).getTime() - new Date(a.date).getTime()
+          (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime(),
         );
         setMatches(data);
       } catch (err) {
-        setError('No se pudieron obtener los partidos.');
+        setError("No se pudieron obtener los partidos.");
       } finally {
         setLoading(false);
       }
@@ -42,73 +41,79 @@ export default function MatchesPage() {
     <main
       style={{
         maxWidth: 480,
-        margin: '48px auto',
+        margin: "48px auto",
         padding: 24,
-        background: 'white',
+        background: "white",
         borderRadius: 12,
-        boxShadow: '0 2px 16px rgba(0,0,0,0.08)',
-        display: 'flex',
-        flexDirection: 'column',
+        boxShadow: "0 2px 16px rgba(0,0,0,0.08)",
+        display: "flex",
+        flexDirection: "column",
         minHeight: 400,
       }}
     >
       <h1
         style={{
-          fontSize: '2rem',
+          fontSize: "2rem",
           fontWeight: 800,
           marginBottom: 24,
-          textAlign: 'center',
-          color: '#0f172a',
+          textAlign: "center",
+          color: "#0f172a",
         }}
       >
         Partidos Jugados
       </h1>
       {loading ? (
-        <p style={{ textAlign: 'center' }}>Cargando...</p>
+        <p style={{ textAlign: "center" }}>Cargando...</p>
       ) : error ? (
-        <p style={{ textAlign: 'center', color: 'red' }}>{error}</p>
+        <p style={{ textAlign: "center", color: "red" }}>{error}</p>
       ) : (
-        <ul style={{ listStyle: 'none', padding: 0 }}>
+        <ul style={{ listStyle: "none", padding: 0 }}>
           {matches.map((m, i) => {
             const expanded = expandedId === m.id;
             return (
-              <li key={m.id} style={{ borderBottom: '1px solid #e5e7eb', fontSize: 14 }}>
+              <li
+                key={m.id}
+                style={{ borderBottom: "1px solid #e5e7eb", fontSize: 14 }}
+              >
                 <button
                   onClick={() => setExpandedId(expanded ? null : m.id)}
                   style={{
-                    all: 'unset',
-                    display: 'flex',
-                    justifyContent: 'space-between',
-                    width: '100%',
-                    padding: '4px 0',
-                    cursor: 'pointer',
+                    all: "unset",
+                    display: "flex",
+                    justifyContent: "space-between",
+                    width: "100%",
+                    padding: "4px 0",
+                    cursor: "pointer",
                   }}
                 >
-                  <span style={{ width: 24 }}>{i + 1}.</span>
                   <span style={{ flex: 1 }}>
                     {new Date(m.date).toLocaleDateString()}
                   </span>
-                  <span style={{ flex: 1, textAlign: 'center' }}>
+                  <span style={{ flex: 1, textAlign: "center" }}>
                     Ganador: Equipo {m.winner}
                   </span>
-                  <span style={{ width: 70, textAlign: 'right' }}>
+                  <span style={{ width: 70, textAlign: "right" }}>
                     Dif: {m.goalDifference}
                   </span>
                 </button>
                 {expanded && (
-                  <div style={{ display: 'flex', gap: 16, padding: '8px 0' }}>
+                  <div style={{ display: "flex", gap: 16, padding: "8px 0" }}>
                     <div style={{ flex: 1 }}>
-                      <p style={{ fontWeight: 600, marginBottom: 4 }}>Equipo A</p>
-                      <ul style={{ listStyle: 'none', padding: 0 }}>
-                        {m.teamAPlayers.map(p => (
+                      <p style={{ fontWeight: 600, marginBottom: 4 }}>
+                        Equipo A
+                      </p>
+                      <ul style={{ listStyle: "none", padding: 0 }}>
+                        {m.teamAPlayers.map((p) => (
                           <li key={p}>{p}</li>
                         ))}
                       </ul>
                     </div>
                     <div style={{ flex: 1 }}>
-                      <p style={{ fontWeight: 600, marginBottom: 4 }}>Equipo B</p>
-                      <ul style={{ listStyle: 'none', padding: 0 }}>
-                        {m.teamBPlayers.map(p => (
+                      <p style={{ fontWeight: 600, marginBottom: 4 }}>
+                        Equipo B
+                      </p>
+                      <ul style={{ listStyle: "none", padding: 0 }}>
+                        {m.teamBPlayers.map((p) => (
                           <li key={p}>{p}</li>
                         ))}
                       </ul>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -16,6 +16,7 @@ export default function Home() {
       </h1>
       <a href="/ranking" style={{ color: '#2563EB' }}>Ver Ranking</a>
       <a href="/teams" style={{ color: '#16a34a' }}>Generar Equipos</a>
+      <a href="/matches" style={{ color: '#6b7280' }}>Ver Partidos</a>
       <a href="/match" style={{ color: '#db2777' }}>Cargar Resultado</a>
     </main>
   );


### PR DESCRIPTION
## Summary
- add `/matches` page to display matches summary
- link new page from home

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68447a5b3900833183697dc200b6b2a4