### PR TITLE
Add players listing page

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -15,6 +15,7 @@ export default function Home() {
         Football Manager
       </h1>
       <a href="/ranking" style={{ color: '#2563EB' }}>Ver Ranking</a>
+      <a href="/players" style={{ color: '#0ea5e9' }}>Ver Jugadores</a>
       <a href="/teams" style={{ color: '#16a34a' }}>Generar Equipos</a>
       <a href="/matches" style={{ color: '#6b7280' }}>Ver Partidos</a>
       <a href="/match" style={{ color: '#db2777' }}>Cargar Resultado</a>

--- a/app/players/page.tsx
+++ b/app/players/page.tsx
@@ -1,0 +1,73 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+interface Player {
+  id: string;
+  name: string;
+}
+
+export default function PlayersPage() {
+  const apiUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3000';
+  const [players, setPlayers] = useState<Player[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchPlayers = async () => {
+      try {
+        const res = await fetch(`${apiUrl}/players`);
+        const data: Player[] = await res.json();
+        data.sort((a, b) => a.name.localeCompare(b.name));
+        setPlayers(data);
+      } catch (err) {
+        setError('No se pudieron obtener los jugadores.');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchPlayers();
+  }, []);
+
+  return (
+    <main
+      style={{
+        maxWidth: 420,
+        margin: '48px auto',
+        padding: 24,
+        background: 'white',
+        borderRadius: 12,
+        boxShadow: '0 2px 16px rgba(0,0,0,0.08)',
+        display: 'flex',
+        flexDirection: 'column',
+        minHeight: 400,
+      }}
+    >
+      <h1
+        style={{
+          fontSize: '2rem',
+          fontWeight: 800,
+          marginBottom: 24,
+          textAlign: 'center',
+          color: '#0ea5e9',
+        }}
+      >
+        Jugadores
+      </h1>
+      {loading ? (
+        <p style={{ textAlign: 'center', color: '#64748b' }}>Cargando...</p>
+      ) : error ? (
+        <p style={{ textAlign: 'center', color: 'red' }}>{error}</p>
+      ) : (
+        <ul style={{ listStyle: 'none', padding: 0 }}>
+          {players.map((p) => (
+            <li key={p.id} style={{ padding: '4px 0' }}>
+              {p.name}
+            </li>
+          ))}
+        </ul>
+      )}
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- add a `/players` page that fetches and displays players alphabetically
- link to the new page from the home screen

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844b35bb7888331969ee03c09ee2b1e